### PR TITLE
feat: Allow user board creation and fix AI features

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,16 @@
             <!-- === ДАШБОРД ПОЛЬЗОВАТЕЛЯ (СПИСОК ДОСОК) === -->
             <div id="dashboard-view" v-if="user.role !== 'projectAdmin' && !currentProject" class="p-8">
                  <h2 class="text-3xl font-bold mb-6">Ваши доски</h2>
+
+                 <!-- Форма создания новой доски для обычных пользователей -->
+                 <div class="bg-white p-6 rounded-xl shadow-lg mb-8">
+                    <h3 class="text-xl font-bold mb-4">Создать новую доску</h3>
+                    <form @submit.prevent="createProject" class="flex gap-2">
+                        <input type="text" v-model="newProject.title" placeholder="Название новой доски" class="flex-grow border-gray-300 rounded-lg shadow-sm">
+                        <button type="submit" class="bg-blue-500 text-white px-5 py-2 rounded-lg font-semibold hover:bg-blue-600 transition">+</button>
+                    </form>
+                </div>
+
                  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
                      <div v-for="p in userProjects" :key="p.id" @click="selectProject(p.id)" class="bg-white p-6 rounded-xl shadow-lg cursor-pointer hover:shadow-xl hover:-translate-y-1 transition-all">
                          <h3 class="text-xl font-bold text-gray-800">{{ p.title }}</h3>


### PR DESCRIPTION
This commit implements two major changes based on user feedback.

First, it allows users with the 'user' role to create their own projects. The project creation form, previously only available to admins, is now also included on the main user dashboard.

Second, it diagnoses and fixes issues with the AI-powered features. This includes:
- Adding robust error handling when fetching project members. The app now shows a clear alert if members cannot be fetched (e.g., due to RLS policies), which was the likely cause of the AI failures.
- Adding checks to the AI helper and analysis functions to prevent them from running with incomplete data.
- Re-implementing the per-project AI analysis on the Kanban board view, now backed by the more robust data fetching and error handling.
- Fixing a bug in the AI task helper that caused it to use a global user list instead of project-specific members.