### PR TITLE
fix: Correct reactivity bug in Kanban board

### DIFF
--- a/js/composables/useKanban.js
+++ b/js/composables/useKanban.js
@@ -11,7 +11,9 @@ export function useKanban(currentProject) {
     let draggedTaskId = null;
 
     const getTasksForColumn = (columnId) => {
-        return computed(() => currentProject.value?.tasks.filter(t => t.column_id === columnId) || []).value;
+        // Return the filtered array directly. Reactivity is handled by Vue because
+        // it tracks the dependency on `currentProject.value.tasks` within the template.
+        return currentProject.value?.tasks.filter(t => t.column_id === columnId) || [];
     };
 
     const addColumn = async () => {


### PR DESCRIPTION
This commit fixes a critical bug introduced in the previous refactoring that caused tasks not to be rendered on the Kanban board.

The `getTasksForColumn` function within the `useKanban.js` composable was incorrectly using `computed(...).value`. This broke Vue's reactivity, as the value was calculated only once and not updated when the project data was loaded asynchronously.

The fix removes the unnecessary `computed` wrapper and allows Vue's standard reactivity to correctly track dependencies on `currentProject.value.tasks`, ensuring tasks are rendered and updated as expected.